### PR TITLE
feature/update-todo-font-checkbox-styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Updated Favicon (Joystick)
+- Updated To Do font and checkbox styles
 
 # v1.4.1 - 26th June 2023
 

--- a/src/components/todo/todo.styles.scss
+++ b/src/components/todo/todo.styles.scss
@@ -53,7 +53,7 @@ $breakpoint-tablet: 768px;
       border: 2px solid $primary-color;
       color: #ffffff;
       flex-grow: 1;
-      font-family: 'Roboto Condensed', sans-serif;
+      font-family: 'Press Start 2P', cursive;
       font-size: 1rem;
       margin-bottom: 10px;
       overflow: hidden;
@@ -118,20 +118,24 @@ $breakpoint-tablet: 768px;
 
     .task-checkbox {
       appearance: none;
-      background-color: transparent;
-      border: 2px solid $button-border-color;
-      border-radius: 50%;
+      background-color: #2c2c2c;
+      border: 3px solid $button-border-color;
+      border-radius: 3px;
       cursor: pointer;
-      height: 20px;
+      flex-shrink: 0;
+      height: 24px;
       margin-right: 20px;
       position: relative;
-      width: 20px;
+      transition: all 0.2s ease-in-out;
+      width: 24px;
 
       &::before {
-        color: #fff;
+        color: $checkbox-color;
         content: '';
         display: none;
-        font-size: 14px;
+        font-family: 'Press Start 2P', cursive;
+        font-size: 10px;
+        font-weight: bold;
         left: 50%;
         position: absolute;
         top: 50%;
@@ -139,21 +143,24 @@ $breakpoint-tablet: 768px;
       }
 
       &:checked {
-        background-color: $checkbox-color;
+        background-color: #1a1a1a;
         border-color: $checkbox-color;
+        box-shadow: inset 0 0 8px $checkbox-color;
 
         &::before {
-          content: '\2713';
+          content: '✓';
           display: block;
         }
       }
 
       &:focus {
-        outline: none;
+        outline: 2px solid $checkbox-color;
+        outline-offset: 2px;
       }
 
       &:hover {
         border-color: $checkbox-color;
+        box-shadow: 0 0 5px rgba(119, 221, 119, 0.5);
       }
     }
 
@@ -170,7 +177,7 @@ $breakpoint-tablet: 768px;
       border-radius: 5px;
       box-shadow: inset 0 0 5px $secondary-color;
       color: #ffffff;
-      font-family: 'Roboto Condensed', sans-serif;
+      font-family: 'Press Start 2P', cursive;
       font-size: 1rem;
       margin-bottom: 10px;
       padding: 8px 12px;
@@ -181,7 +188,7 @@ $breakpoint-tablet: 768px;
         border: 2px solid $primary-color;
         color: #ffffff;
         flex-grow: 1;
-        font-family: 'Roboto Condensed', sans-serif;
+        font-family: 'Press Start 2P', cursive;
         font-size: 1rem;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
## Description of Changes

This PR updates the To-Do app's font usage for consistency across all input fields, buttons, and task items, ensuring a cohesive retro aesthetic. Additionally, the checkbox style has been enhanced to better fit the retro theme, switching from a circular to a square design with a pixel-style checkmark and improved focus/hover states.

## Type of Change

- [x] New Feature

## Describe the problem this PR solves and your solution.

**Problem:**  
The app previously used inconsistent fonts, with the input field and task items not matching the intended retro game vibe. The checkbox was circular and did not fit the pixel/retro aesthetic.

**Solution:**  
- Updated all relevant elements (input, buttons, task text, edit input) to use `'Press Start 2P', cursive` for a consistent retro look.
- Enhanced the checkbox style:  
  - Changed from circular to square.
  - Added a pixel-style checkmark using the theme color.
  - Improved focus and hover states for accessibility and visual feedback.

## Testing Steps

1. Run the app locally.
2. Add a new task and observe the input font and button font.
3. Check/uncheck a task and verify the new square checkbox style and checkmark.
4. Edit a task and confirm the edit input uses the correct font.
5. Hover and focus on the checkbox to see the updated states.
6. Confirm all colours remain consistent with the theme.

## Screenshots / Video

https://github.com/user-attachments/assets/17e6631f-8832-4523-a3b3-605eafd64dda

## Checklist

_Tick once complete_

- [x] My code follows the code style of this project
- [x] This PR doesn't include breaking changes
- [x] Manual tests have been completed
- [x] Line in CHANGELOG.md has been added
- [x] Logs etc. have been removed
- [x] Testing steps have been added for the reviewer